### PR TITLE
feat(users): PUT/PATCH/DELETE; extract JSON helpers

### DIFF
--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -50,4 +51,74 @@ func errorJSON(w http.ResponseWriter, status int, msg string) {
 		Error: msg,
 		Code:  http.StatusText(status)}
 	writeJSON(w, status, err)
+}
+
+var (
+	ErrBodyTooLarge  = errors.New("body too large")
+	ErrInvalidSyntax = errors.New("invalid json syntax")
+	ErrWrongType     = errors.New("wrong json type")
+	ErrUnknownField  = errors.New("unknown field")
+	ErrEmptyBody     = errors.New("empty body")
+	ErrTrailingData  = errors.New("multiple json values")
+)
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, dst any, maxBytes int64) error {
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+
+	if err := dec.Decode(dst); err != nil {
+
+		if err == io.EOF {
+			return ErrEmptyBody
+		}
+
+		var se *json.SyntaxError
+		if errors.As(err, &se) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return ErrInvalidSyntax
+		}
+
+		var te *json.UnmarshalTypeError
+		if errors.As(err, &te) {
+			return ErrWrongType
+		}
+
+		if strings.Contains(err.Error(), "unknown field") {
+			return ErrUnknownField
+		}
+
+		if strings.Contains(err.Error(), "request body too large") {
+			return ErrBodyTooLarge
+		}
+
+		return err
+	}
+
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		return ErrTrailingData
+	}
+
+	return nil
+}
+
+func respondDecodeError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrBodyTooLarge):
+		errorJSON(w, http.StatusRequestEntityTooLarge, "request body too large")
+	case errors.Is(err, ErrInvalidSyntax):
+		errorJSON(w, http.StatusBadRequest, "invalid JSON")
+	case errors.Is(err, ErrWrongType):
+		errorJSON(w, http.StatusBadRequest, "wrong type")
+	case errors.Is(err, ErrUnknownField):
+		errorJSON(w, http.StatusBadRequest, "unknown field")
+	case errors.Is(err, ErrEmptyBody):
+		errorJSON(w, http.StatusBadRequest, "empty body")
+	case errors.Is(err, ErrTrailingData):
+		errorJSON(w, http.StatusBadRequest, "body must contain a single JSON value")
+	default:
+		errorJSON(w, http.StatusBadRequest, "invalid JSON")
+	}
 }

--- a/internal/service/users.go
+++ b/internal/service/users.go
@@ -46,3 +46,43 @@ func GetUserByID(id int) (User, bool) {
 	return u, ok
 
 }
+
+func UpdateUserByID(id int, name, email string) (User, bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	updated, ok := users[id]
+	if !ok {
+		return User{}, false
+	}
+	updated.Name = name
+	updated.Email = email
+	users[id] = updated
+	return updated, true
+}
+func PatchUserByID(id int, name, email *string) (User, bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	updated, ok := users[id]
+	if !ok {
+		return User{}, false
+	}
+	if name != nil {
+		updated.Name = *name
+	}
+	if email != nil {
+		updated.Email = *email
+	}
+	users[id] = updated
+	return updated, true
+}
+
+func DeleteUserByID(id int) bool {
+	mu.Lock()
+	defer mu.Unlock()
+	_, ok := users[id]
+	if !ok {
+		return false
+	}
+	delete(users, id)
+	return true
+}


### PR DESCRIPTION
add decodeJSON and respondDecodeError helpers; use writeJSON/errorJSON

enforce Content-Type and request size limits

PATCH supports partial updates via pointer fields

DELETE returns 204 No Content; 405 includes Allow header

unify response DTO (UserResponse) and path parsing via parseUserID

remove ad-hoc json.Decoder usage from handlers